### PR TITLE
Attempt to avoid random kernel panic reboots

### DIFF
--- a/drivers/soc/qcom/qmi_rmnet.c
+++ b/drivers/soc/qcom/qmi_rmnet.c
@@ -14,7 +14,6 @@
 #include <trace/events/dfc.h>
 #include <linux/ip.h>
 #include <linux/ipv6.h>
-#include <linux/alarmtimer.h>
 
 #define NLMSG_FLOW_ACTIVATE 1
 #define NLMSG_FLOW_DEACTIVATE 2
@@ -45,7 +44,6 @@ unsigned int rmnet_wq_frequency __read_mostly = 1000;
 #define PS_INTERVAL (((!rmnet_wq_frequency) ?                             \
 					1 : rmnet_wq_frequency/10) * (HZ/100))
 #define NO_DELAY (0x0000 * HZ)
-#define PS_INTERVAL_KT (ms_to_ktime(1000))
 #define WATCHDOG_EXPIRE_JF (msecs_to_jiffies(50))
 
 #ifdef CONFIG_QCOM_QMI_DFC
@@ -1051,7 +1049,6 @@ static LIST_HEAD(ps_list);
 
 struct rmnet_powersave_work {
 	struct delayed_work work;
-	struct alarm atimer;
 	void *port;
 	u64 old_rx_pkts;
 	u64 old_tx_pkts;
@@ -1136,16 +1133,6 @@ static void qmi_rmnet_work_restart(void *port)
 	rcu_read_unlock();
 }
 
-static enum alarmtimer_restart qmi_rmnet_work_alarm(struct alarm *atimer,
-						    ktime_t now)
-{
-	struct rmnet_powersave_work *real_work;
-
-	real_work = container_of(atimer, struct rmnet_powersave_work, atimer);
-	qmi_rmnet_work_restart(real_work->port);
-	return ALARMTIMER_NORESTART;
-}
-
 static void qmi_rmnet_check_stats(struct work_struct *work)
 {
 	struct rmnet_powersave_work *real_work;
@@ -1153,7 +1140,6 @@ static void qmi_rmnet_check_stats(struct work_struct *work)
 	u64 rxd, txd;
 	u64 rx, tx;
 	bool dl_msg_active;
-	bool use_alarm_timer = true;
 
 	real_work = container_of(to_delayed_work(work),
 				 struct rmnet_powersave_work, work);
@@ -1199,10 +1185,8 @@ static void qmi_rmnet_check_stats(struct work_struct *work)
 		 * (likely in RLF), no need to enter powersave
 		 */
 		if (!dl_msg_active &&
-		    !rmnet_all_flows_enabled(real_work->port)) {
-			use_alarm_timer = false;
+		    !rmnet_all_flows_enabled(real_work->port))
 			goto end;
-		}
 
 		/* Deregister to suppress QMI DFC and DL marker */
 		if (qmi_rmnet_set_powersave_mode(real_work->port, 1) < 0)
@@ -1226,14 +1210,8 @@ static void qmi_rmnet_check_stats(struct work_struct *work)
 	}
 end:
 	rcu_read_lock();
-	if (!rmnet_work_quit) {
-		if (use_alarm_timer)
-			alarm_start_relative(&real_work->atimer,
-					     PS_INTERVAL_KT);
-		else
-			queue_delayed_work(rmnet_ps_wq, &real_work->work,
-					   PS_INTERVAL);
-	}
+	if (!rmnet_work_quit)
+		queue_delayed_work(rmnet_ps_wq, &real_work->work, PS_INTERVAL);
 	rcu_read_unlock();
 }
 
@@ -1269,7 +1247,6 @@ void qmi_rmnet_work_init(void *port)
 		return;
 	}
 	INIT_DEFERRABLE_WORK(&rmnet_work->work, qmi_rmnet_check_stats);
-	alarm_init(&rmnet_work->atimer, ALARM_BOOTTIME, qmi_rmnet_work_alarm);
 	rmnet_work->port = port;
 	rmnet_get_packets(rmnet_work->port, &rmnet_work->old_rx_pkts,
 			  &rmnet_work->old_tx_pkts);
@@ -1303,7 +1280,6 @@ void qmi_rmnet_work_exit(void *port)
 	synchronize_rcu();
 
 	rmnet_work_inited = false;
-	alarm_cancel(&rmnet_work->atimer);
 	cancel_delayed_work_sync(&rmnet_work->work);
 	destroy_workqueue(rmnet_ps_wq);
 	qmi_rmnet_work_set_active(port, 0);

--- a/drivers/soc/qcom/qmi_rmnet.c
+++ b/drivers/soc/qcom/qmi_rmnet.c
@@ -1234,8 +1234,7 @@ void qmi_rmnet_work_init(void *port)
 	if (rmnet_ps_wq)
 		return;
 
-	rmnet_ps_wq = alloc_workqueue("rmnet_powersave_work",
-				      WQ_CPU_INTENSIVE, 1);
+	rmnet_ps_wq = create_freezable_workqueue("rmnet_powersave_work");
 
 	if (!rmnet_ps_wq)
 		return;


### PR DESCRIPTION
I'm experiencing random kernel panic reboots on my alioth. Googling strings appeared in `/sys/fs/pstore/console-ramoops-0` like "qmi_rmnet_set_powersave_mode" etc led me [here](https://forum.xda-developers.com/t/rom-11-0-0-alioth-aliothin-arrowos-11-0-official-weekly.4279481/page-53#post-85401431) and that user then said ["No longer getting crashes/reboots with the August 2nd build but instead get a bunch of network resets"](https://forum.xda-developers.com/t/rom-11-0-0-alioth-aliothin-arrowos-11-0-official-weekly.4279481/post-85419703)

I think at least network resets seem to be better than the whole system crashes randomly. Therefore I decided to patch the kernel & see what's coming. I've managed to compile the kernel (with the help of tons of googling...) & it seems to work, except that a "There is an internal problem in your device. Please contact your manufacturer" popup shows every time the device boots into lockscreen which doesn't seem to be an issue.

--------

I built the kernel without doing a full `repo sync` etc. I just cloned this "android_kernel_xiaomi_sm8250" repository.

The latest android-ndk-r23b didn't seem to work, so that I switched to older android-ndk-r22b & it worked.

I modified `.config` (originally pulled from `/proc/config.gz` on alioth) to build some modules I'm personally interested in, like nfs, tcp_bbr etc. I then found that the `/vendor` has insufficient inode count to contain additional kernel driver files so that I reformatted that partition to enlarge inode count.

```Shell
export PATH=${NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/bin:${NDK_PATH}/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64/bin:${NDK_PATH}/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin:$PATH

make -j$(nproc --all) O=output_dir INSTALL_MOD_STRIP=1 INSTALL_MOD_PATH=modules_install_dir ARCH=arm64 SUBARCH=arm64 CC=clang CLANG_TRIPLE=aarch64-linux-gnu- CROSS_COMPILE=aarch64-linux-android- CROSS_COMPILE_ARM32=arm-linux-androideabi-

make modules_install

KERNEL_VERSION=$(awk '{print $3}' output_dir/include/generated/utsrelease.h | tr -d "\"")
mkdir -p output_dir/modules/lib/modules/${KERNEL_VERSION}/
cp output_dir/modules.builtin output_dir/modules/lib/modules/${KERNEL_VERSION}/
cp output_dir/modules.order output_dir/modules/lib/modules/${KERNEL_VERSION}/
find output_dir/modules_install_dir | grep ko$ | while read FILE; do
    cp ${FILE} output_dir/modules/lib/modules/${KERNEL_VERSION}/
done
depmod --all --basedir=output_dir/modules --filesyms=output_dir/System.map --symvers=output_dir/Module.symvers ${KERNEL_VERSION}
```

There were some compilation errors but I [managed to get through them](https://github.com/ClassfulNick/android_kernel_xiaomi_sm8250/tree/fix-compilation-error). Also, I found that `make clean` (or `make mrproper` etc) deleted some driver firmware files with `.i` file extension, but then I found that this issue doesn't arise if `O=output_dir` is given.

Finally I used `libmagiskboot.so` inside Magisk.apk to replace the kernel.