### PR TITLE
Prevent hard reset on modem crash

### DIFF
--- a/drivers/soc/qcom/subsystem_restart.c
+++ b/drivers/soc/qcom/subsystem_restart.c
@@ -1245,19 +1245,8 @@ int subsystem_restart_dev(struct subsys_device *dev)
 		return 0;
 	}
 
-	switch (dev->restart_level) {
+	__subsystem_restart_dev(dev);
 
-	case RESET_SUBSYS_COUPLED:
-		__subsystem_restart_dev(dev);
-		break;
-	case RESET_SOC:
-		__pm_stay_awake(dev->ssr_wlock);
-		schedule_work(&dev->device_restart_work);
-		return 0;
-	default:
-		panic("subsys-restart: Unknown restart level!\n");
-		break;
-	}
 	module_put(dev->owner);
 	put_device(&dev->dev);
 


### PR DESCRIPTION
Same as #1, but I think I found the right commit to cherry-pick this time.

*Note that https://github.com/xiaomi-sm8250-devs/android_kernel_xiaomi_sm8250/commit/0e5d86242eb76418294fe729c7792346df26debb (originally https://github.com/libxzr/android_kernel_oneplus_sm8250/commit/578bed2765470821eea0b8ccfbcbfb3498415c7d) doesn't revert anything because the change it was meant to revert is not applied to this version of kernel yet. However I still leave it here.*